### PR TITLE
Feature/new frame

### DIFF
--- a/src/ofxCvPiCam.cpp
+++ b/src/ofxCvPiCam.cpp
@@ -7,6 +7,7 @@ int ofxCvPiCam::width = 0;
 int ofxCvPiCam::height = 0;
 MMAL_POOL_T * ofxCvPiCam::camera_video_port_pool = NULL;
 Mat ofxCvPiCam::image = Mat();
+bool ofxCvPiCam::newFrame = false;
 static void gray_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer) {
     MMAL_BUFFER_HEADER_T *new_buffer;
     mmal_buffer_header_mem_lock(buffer);

--- a/src/ofxCvPiCam.cpp
+++ b/src/ofxCvPiCam.cpp
@@ -21,8 +21,6 @@ static void gray_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer) {
         if (!new_buffer || status != MMAL_SUCCESS)
             ofLogVerbose() << ("Unable to return a buffer to the video port\n");
     }
-    newFrame = true;
-
 }
 
 static void color_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer) {
@@ -39,7 +37,6 @@ static void color_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer) {
         if (!new_buffer || status != MMAL_SUCCESS)
             ofLogVerbose() << ("Unable to return a buffer to the video port\n");
     }
-    newFrame = true;
 }
 void ofxCvPiCam::setup(int _w,int _h,bool _color)
 {

--- a/src/ofxCvPiCam.cpp
+++ b/src/ofxCvPiCam.cpp
@@ -21,6 +21,8 @@ static void gray_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer) {
         if (!new_buffer || status != MMAL_SUCCESS)
             ofLogVerbose() << ("Unable to return a buffer to the video port\n");
     }
+    newFrame = true;
+
 }
 
 static void color_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer) {
@@ -37,6 +39,7 @@ static void color_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer) {
         if (!new_buffer || status != MMAL_SUCCESS)
             ofLogVerbose() << ("Unable to return a buffer to the video port\n");
     }
+    newFrame = true;
 }
 void ofxCvPiCam::setup(int _w,int _h,bool _color)
 {

--- a/src/ofxCvPiCam.h
+++ b/src/ofxCvPiCam.h
@@ -49,10 +49,11 @@ public:
     void setup();
 
     static cv::Mat image;
+    static bool newFrame;
 
     static int width, height;
     static MMAL_POOL_T *camera_video_port_pool;
-    static void set_image(cv::Mat _image) {image = _image;}
+    static void set_image(cv::Mat _image) {newFrame = true; image = _image;}
     void setup(int _w, int _h, bool _color);
     cv::Mat grab() {newFrame = false; return image;}
     MMAL_COMPONENT_T *getCamera(){ return camera; }
@@ -185,7 +186,7 @@ public:
     }
     //*/
 private:
-    bool color, newFrame;
+    bool color;
     MMAL_COMPONENT_T *camera;
     MMAL_COMPONENT_T *preview;
     MMAL_ES_FORMAT_T *format;

--- a/src/ofxCvPiCam.h
+++ b/src/ofxCvPiCam.h
@@ -43,6 +43,9 @@ public:
 
     ofxCvPiCam();
     ~ofxCvPiCam();
+
+    bool isFrameNew() {return newFrame;};
+
     void setup();
 
     static cv::Mat image;
@@ -51,7 +54,7 @@ public:
     static MMAL_POOL_T *camera_video_port_pool;
     static void set_image(cv::Mat _image) {image = _image;}
     void setup(int _w, int _h, bool _color);
-    cv::Mat grab() {return image;}
+    cv::Mat grab() {newFrame = false; return image;}
     MMAL_COMPONENT_T *getCamera(){ return camera; }
 
     //settings
@@ -182,7 +185,7 @@ public:
     }
     //*/
 private:
-    bool color;
+    bool color, newFrame;
     MMAL_COMPONENT_T *camera;
     MMAL_COMPONENT_T *preview;
     MMAL_ES_FORMAT_T *format;


### PR DESCRIPTION
this patch add a `newFrame` member variable accessible via `isFrameNew()` member function.
 `newFrame` is set to `true` when a new frame arrive from mmal callback method.
 `newFrame` is set to `false` when you grab a frame.

so to process frames only once, you should do something like : 

```
ofxCvPiCam cam;
if ( cam.isFrameNew() ){
  cam.grab();
  // so some processing
}
```

this fixes https://github.com/orgicus/ofxCvPiCam/issues/5
